### PR TITLE
feat: add Soulink agent identity memory example

### DIFF
--- a/examples/soulink-identity.ts
+++ b/examples/soulink-identity.ts
@@ -1,0 +1,96 @@
+/**
+ * Soulink Agent Identity + Hyperspell Memory
+ *
+ * Persists verified on-chain agent identities into the memory graph.
+ * Agents remember who they've interacted with and their trust levels,
+ * grounded in Soulink's on-chain credit scores (not hallucinated context).
+ *
+ * Soulink: https://soulink.dev
+ */
+import Hyperspell from 'hyperspell'
+
+const SOULINK_API = 'https://soulink.dev/api/v1'
+
+const client = new Hyperspell({
+  apiKey: process.env['HYPERSPELL_API_KEY'],
+})
+
+interface SoulinkIdentity {
+  name: string
+  owner: string
+  expires_at: string
+}
+
+interface SoulinkCredit {
+  name: string
+  score: number
+  total_reports: number
+}
+
+async function resolveAgent(name: string): Promise<SoulinkIdentity> {
+  const res = await fetch(`${SOULINK_API}/resolve/${encodeURIComponent(name)}`)
+  if (!res.ok) throw new Error(`Failed to resolve ${name}: ${res.status}`)
+  return res.json() as Promise<SoulinkIdentity>
+}
+
+async function getCredit(name: string): Promise<SoulinkCredit> {
+  const res = await fetch(`${SOULINK_API}/credit/${encodeURIComponent(name)}`)
+  if (!res.ok) throw new Error(`Failed to get credit for ${name}: ${res.status}`)
+  return res.json() as Promise<SoulinkCredit>
+}
+
+// Store your own agent's identity in memory on startup
+async function persistSelfIdentity(agentName: string) {
+  const identity = await resolveAgent(agentName)
+  const credit = await getCredit(agentName)
+
+  await client.memories.add({
+    text: [
+      `I am ${identity.name}.agent.`,
+      `My wallet is ${identity.owner}.`,
+      `My credit score is ${credit.score}/100 based on ${credit.total_reports} reports.`,
+    ].join(' '),
+  })
+
+  console.log(`Persisted self identity: ${identity.name} (score: ${credit.score})`)
+}
+
+// Remember another agent after interacting with them
+async function rememberAgent(agentName: string) {
+  const identity = await resolveAgent(agentName)
+  const credit = await getCredit(agentName)
+
+  await client.memories.add({
+    text: [
+      `Agent ${identity.name}.agent has a credit score of ${credit.score}/100`,
+      `based on ${credit.total_reports} reports.`,
+      `Their wallet is ${identity.owner}.`,
+      `Last seen: ${new Date().toISOString()}.`,
+    ].join(' '),
+  })
+
+  console.log(`Remembered agent: ${identity.name} (score: ${credit.score})`)
+}
+
+// Search memory for agents you've interacted with
+async function recallAgents(query: string) {
+  const results = await client.memories.search({ text: query })
+  console.log(`Found ${results.length} matching memories:`)
+  for (const result of results) {
+    console.log(`  - ${result.resource_id}`)
+  }
+  return results
+}
+
+async function main() {
+  // On startup, persist your own identity
+  await persistSelfIdentity('my-agent')
+
+  // After interacting with another agent, remember them
+  await rememberAgent('helper-bot')
+
+  // Later, recall trusted agents from memory
+  await recallAgents('credit score agent')
+}
+
+main().catch(console.error)


### PR DESCRIPTION
## Summary

Adds an example showing how to persist verified on-chain agent identities into the Hyperspell memory graph using [Soulink](https://soulink.dev).

- **Resolve** `.agent` names via Soulink API to get verified wallet addresses
- **Store** self identity in memory on startup — agent knows who it is across sessions
- **Remember** other agents after interactions, tagged with on-chain credit scores
- **Search** memory for previously seen agents by trust level

## Why this pairing

Hyperspell gives agents persistent memory. Soulink gives agents verified on-chain identity (`.agent` names + credit scores on Base). Together, trust decisions are grounded in real on-chain reputation data, not hallucinated context.

## What's changed

- Added `examples/soulink-identity.ts` — standalone example, no changes to SDK code

## Links

- [Soulink](https://soulink.dev) — On-chain identity for AI agents
- [Soulink API](https://soulink.dev/skill.md) — Agent-readable API guide