### PR TITLE
feat: add 'mood' to memory type unions

### DIFF
--- a/src/resources/memories.ts
+++ b/src/resources/memories.ts
@@ -599,7 +599,7 @@ export namespace MemorySearchParams {
      * Filter by memory type. Defaults to generic memories only. Pass multiple types to
      * include procedures, etc.
      */
-    memory_types?: Array<'procedure' | 'memory'>;
+    memory_types?: Array<'procedure' | 'memory' | 'mood'>;
 
     /**
      * Search options for Notion

--- a/src/resources/sessions.ts
+++ b/src/resources/sessions.ts
@@ -54,7 +54,7 @@ export interface SessionAddParams {
   /**
    * What kind of memories to extract from the trace
    */
-  extract?: Array<'procedure' | 'memory'>;
+  extract?: Array<'procedure' | 'memory' | 'mood'>;
 
   /**
    * Trace format: 'vercel', 'hyperdoc', or 'openclaw'. Auto-detected if not set.


### PR DESCRIPTION
## Summary
- Adds `'mood'` to `SessionAddParams.extract` type union
- Adds `'mood'` to `MemorySearchParams.memory_types` type union

Matches the new `MOOD` enum value added to the core API in hyperspell/hyperspell#581 (now merged).

## Test plan
- [ ] Type check passes
- [ ] Existing tests unaffected (additive change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)