### PR TITLE
fix(mcp): execute tool dies on Deno >= 2 (unix socket needs net permission)

### DIFF
--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -141,7 +141,7 @@ const localDenoHandler = async ({
   const packageNodeModulesPath = path.resolve(packageRoot, 'node_modules');
 
   // Check if deno is in PATH
-  const { execSync } = await import('node:child_process');
+  const { execSync, spawn } = await import('node:child_process');
   try {
     execSync('command -v deno', { stdio: 'ignore' });
     denoPath = 'deno';
@@ -157,6 +157,16 @@ const localDenoHandler = async ({
           'Install it from https://deno.land or run: npm install deno',
       );
     }
+  }
+
+  // Deno >= 2 gates unix sockets behind --allow-net=unix:<path>, while Deno 1.x panics on a
+  // `unix:` token in --allow-net — so the socket grant below must be gated on the major version.
+  let denoMajor = 2;
+  try {
+    const versionOutput = execSync(`"${denoPath}" --version`, { encoding: 'utf8' });
+    denoMajor = Number(/deno (\d+)\./.exec(versionOutput)?.[1] ?? denoMajor);
+  } catch {
+    // Version detection failed; assume a current (2.x) Deno.
   }
 
   const allowReadPaths = [
@@ -190,6 +200,29 @@ const localDenoHandler = async ({
       '--allow-env',
     ],
     printOutput: true,
+    // deno-http-worker grants its internal unix socket via --allow-read/--allow-write (the
+    // Deno 1.x permission model), but Deno >= 2 requires --allow-net=unix:<path> or the worker
+    // dies on startup ("Deno exited before being ready"). The socket path is generated inside
+    // newDenoHTTPWorker, so pluck it out of the --allow-write flag the library injects and graft
+    // it onto the --allow-net scope (Deno rejects repeated --allow-net flags, hence the comma).
+    ...(denoMajor >= 2 && {
+      spawnFunc: (
+        command: string,
+        spawnArgs: string[],
+        options: import('node:child_process').SpawnOptions,
+      ) => {
+        const socketPath = spawnArgs
+          .find((flag) => flag.startsWith('--allow-write='))
+          ?.slice('--allow-write='.length)
+          .split(',')
+          .find((segment) => segment.endsWith('-deno-http.sock'));
+        const patchedArgs =
+          socketPath ?
+            spawnArgs.map((flag) => (flag.startsWith('--allow-net=') ? `${flag},unix:${socketPath}` : flag))
+          : spawnArgs;
+        return spawn(command, patchedArgs, options);
+      },
+    }),
     spawnOptions: {
       cwd: path.dirname(workerPath),
       // Merge any upstream client envs into the Deno subprocess environment,


### PR DESCRIPTION
## Problem

Every `execute` call on `@hyperspell/hyperspell-mcp@0.40.0` fails with **"Deno exited before being ready"** on any modern Deno (found during the 2026-07-16 MCP/CLI test battery). The failure is silent — health checks and `tools/list` still report the server as connected.

Root cause: Deno 2.x moved unix sockets under the **net** permission. Listening on the socket `@valtown/deno-http-worker` uses to talk to the sandbox now requires `--allow-net=unix:<path>`, but the library (0.0.21 — and still 2.0.3, so a version bump does **not** fix this; verified empirically) only grants the socket via `--allow-read`/`--allow-write`, the Deno 1.x model:

```
NotCapable: Requires net access to "unix:/var/folders/.../<uuid>-deno-http.sock",
run again with the --allow-net flag
```

## Fix

The socket path is generated inside `newDenoHTTPWorker`, so no flag can be scoped up front — Deno accepts only exact socket paths (no globs or directory prefixes) and rejects repeated `--allow-net` flags. Instead, use the library's `spawnFunc` hook: at spawn time, pluck the socket path out of the `--allow-write` flag the library injects and graft `unix:<sock>` onto the existing `--allow-net` scope (comma-merged into the one flag).

Gated on Deno major ≥ 2: Deno 1.46 **panics** on a `unix:` token in `--allow-net` (tested), and on 1.x the old read/write grant still works.

## Verification (all against Deno 2.9.3, driven over real MCP stdio JSON-RPC)

| Scenario | Result |
|---|---|
| Published `0.40.0`, `tools/call execute` (`return 6 * 7`) | ❌ `Deno exited before being ready` |
| This build, same call | ✅ returns `42` |
| This build, `fetch('https://example.com')` from executed code | ✅ still denied (`NotCapable: Requires net access to "example.com:443"`) — sandbox scoping unchanged |
| `@valtown/deno-http-worker@2.0.3` (the "just bump it" theory) | ❌ fails identically — bump is not a fix |
| Deno 1.46.3 with a `unix:` token in `--allow-net` | 💥 panics — hence the version gate |

`pnpm lint` and `pnpm test` pass; file is prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)