### PR TITLE
fix(mcp): execute tool dies on Deno >= 2.9 (unix sockets moved behind net permission)

### DIFF
--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -159,14 +159,21 @@ const localDenoHandler = async ({
     }
   }
 
-  // Deno >= 2 gates unix sockets behind --allow-net=unix:<path>, while Deno 1.x panics on a
-  // `unix:` token in --allow-net — so the socket grant below must be gated on the major version.
-  let denoMajor = 2;
+  // Deno 2.9.0 moved unix sockets behind the net permission (--allow-net=unix:<path>), part of
+  // the 2.8.2–2.9.1 socket-hardening series (denoland/deno#34395, #35835). Older Denos must NOT
+  // receive the token: 2.0–2.8 reject it at startup ("invalid port") and 1.x panics — and their
+  // legacy read/write grant still works. So gate the grant on exactly >= 2.9.
+  let denoNeedsUnixNetGrant = true;
   try {
     const versionOutput = execSync(`"${denoPath}" --version`, { encoding: 'utf8' });
-    denoMajor = Number(/deno (\d+)\./.exec(versionOutput)?.[1] ?? denoMajor);
+    const versionMatch = /deno (\d+)\.(\d+)\./.exec(versionOutput);
+    if (versionMatch) {
+      const major = Number(versionMatch[1]);
+      const minor = Number(versionMatch[2]);
+      denoNeedsUnixNetGrant = major > 2 || (major === 2 && minor >= 9);
+    }
   } catch {
-    // Version detection failed; assume a current (2.x) Deno.
+    // Version detection failed; assume a current Deno.
   }
 
   const allowReadPaths = [
@@ -201,11 +208,14 @@ const localDenoHandler = async ({
     ],
     printOutput: true,
     // deno-http-worker grants its internal unix socket via --allow-read/--allow-write (the
-    // Deno 1.x permission model), but Deno >= 2 requires --allow-net=unix:<path> or the worker
-    // dies on startup ("Deno exited before being ready"). The socket path is generated inside
-    // newDenoHTTPWorker, so pluck it out of the --allow-write flag the library injects and graft
-    // it onto the --allow-net scope (Deno rejects repeated --allow-net flags, hence the comma).
-    ...(denoMajor >= 2 && {
+    // pre-2.9 permission model — unchanged upstream as of 2.0.3, so a version bump is not a fix),
+    // which on Deno >= 2.9 kills the worker at startup ("Deno exited before being ready").
+    // The socket path is generated inside newDenoHTTPWorker, so no flag can be scoped up front
+    // (Deno accepts only exact socket paths — no globs/prefixes — and rejects repeated
+    // --allow-net flags). Instead, intercept the spawn, pluck the socket path out of the
+    // --allow-write flag the library injects, and comma-merge unix:<sock> onto the existing
+    // --allow-net scope.
+    ...(denoNeedsUnixNetGrant && {
       spawnFunc: (
         command: string,
         spawnArgs: string[],


### PR DESCRIPTION
Supersedes #100, which fixed Deno 2.9 but would have broken 2.0–2.8.

## Problem

Every `execute` call on `@hyperspell/hyperspell-mcp@0.40.0` fails with **"Deno exited before being ready"** on Deno ≥ 2.9 (found in the 2026-07-16 MCP/CLI test battery). Silent: health checks and `tools/list` still pass.

Root cause — pinned down empirically and against Deno's changelog: **Deno 2.9.0 moved unix sockets behind the net permission** (`--allow-net=unix:<path>`), part of the 2.8.2–2.9.1 socket-hardening series (denoland/deno#34395, #35835). `@valtown/deno-http-worker` — 0.0.21 *and* latest 2.0.3, so a dependency bump is not a fix — still grants its Node↔sandbox socket via `--allow-read`/`--allow-write`.

## Fix

The socket path is generated inside `newDenoHTTPWorker`; Deno accepts only exact socket paths (no globs/prefixes) and rejects repeated `--allow-net` flags — so nothing can be scoped up front. Instead use the library's `spawnFunc` hook: extract the socket path from the `--allow-write` flag it injects and comma-merge `unix:<sock>` onto the existing `--allow-net` scope at spawn time.

**Gated on Deno ≥ 2.9 exactly.** This is the critical difference from #100: Deno 2.0–2.8 reject the `unix:` token at startup (`invalid port`) and 1.x panics on it — while their legacy read/write grant still works.

## Verification (real MCP stdio JSON-RPC, real `execute` calls)

| Build | Deno 2.8.3 | Deno 2.9.3 |
|---|---|---|
| Published 0.40.0 | ✅ (legacy grant works) | ❌ `Deno exited before being ready` |
| #100 (`>= 2` gate) | ❌ `invalid port in 'unix:…'` | ✅ |
| **This PR (`>= 2.9` gate)** | ✅ returns `42` | ✅ returns `42` |

Version bracket (worker-level): 2.0.1 / 2.4.4 / 2.6.8 / 2.8.3 all work with legacy grants and all reject the `unix:` token; enforcement starts at 2.9.0. Sandbox unchanged: `fetch('https://example.com')` from executed code still denied (`NotCapable`).

`pnpm lint` + `pnpm test` pass; prettier-clean.

Follow-ups (separate): upstream this into the stlc-mcp codegen source (`packages/sdk-codegen-typescript/src/mcp/code-tool.ts`) so regen doesn't clobber it, and offer the fix to val-town/deno-http-worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)